### PR TITLE
Default currency option when calling $user->creditCurrency method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ return [
      * Default table name.
      * If you have changed the migration, make sure you change this too.
      */
-    'table' => 'balances'
+    'table' => 'balances',
+    'default_currency' => 'EUR', // Default Currency
 ];
 
 ```

--- a/config/balance.php
+++ b/config/balance.php
@@ -5,5 +5,6 @@ return [
      * Default table name.
      * If you have changed the migration, make sure you change this too.
      */
-    'table' => 'balances'
+    'table' => 'balances',
+    'default_currency' => 'USD', // Default currency
 ];

--- a/src/Traits/HasBalance.php
+++ b/src/Traits/HasBalance.php
@@ -23,11 +23,12 @@ trait HasBalance
 
     public function withCurrency(string $currency): self
     {
-        $this->currency = $currency;
+        $clone = clone $this;
+        $clone->currency = $currency;
 
-        return $this;
+        return $clone;
     }
-
+    
     protected function credit(): Attribute
     {
         return Attribute::make(

--- a/src/Traits/HasBalance.php
+++ b/src/Traits/HasBalance.php
@@ -9,7 +9,12 @@ use Illuminate\Support\Number;
 
 trait HasBalance
 {
-    protected string $currency = 'USD';
+    protected string $currency;
+
+    public function __construct()
+    {
+        $this->currency = config('balance.default_currency', 'USD');
+    }
 
     public function credits(): MorphMany
     {


### PR DESCRIPTION
Thanks for the amazing work done on this package.

I made a contribution to the project, Now it is possible to make a currency default and whenever you use the method:

```php
$user->creditCurrency; // $10.00 Returns the default currency.
// It also works for:
$user->withCurrency('EUR')->creditCurrency; // returns €10.00
```

This is possible just by changing in the /config/balance.php file:
```php
return [
    /**
     * Default table name.
     * If you have changed the migration, make sure you change this too.
     */
    'table' => 'balances',
    'default_currency' => 'EUR', // Default Currency
];

```